### PR TITLE
Added new field definition named warning to manticore.yml

### DIFF
--- a/manticore.yml
+++ b/manticore.yml
@@ -213,6 +213,9 @@ components:
                   gid: 20
         profile:
           type: object
+        warning:
+          type: object
+          additionalProperties: true
     sqlResponse:
       type: object
       description: Response from sql depends on the query executed.


### PR DESCRIPTION
Deserialization of SearchResponse fails with:

Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "warning" (class com.manticoresearch.client.model.SearchResponse), not marked as ignorable (4 known properties: "hits", "profile", "timed_out", "took"])

without warning field in SearchResponse.